### PR TITLE
Allow entity to be retrieve from EntityInvalid error

### DIFF
--- a/lib/datamappify/data/errors.rb
+++ b/lib/datamappify/data/errors.rb
@@ -7,8 +7,11 @@ module Datamappify
     end
 
     class EntityInvalid < Error
+      attr_reader :entity
+
       # @param entity [Entity]
       def initialize(entity)
+        @entity = entity
         super entity.errors.full_messages.join(', ')
       end
     end


### PR DESCRIPTION
I'd like to be able to get the entity back from an EntityInvalid error, so that I can send the errors as json. I added this attr reader, but I'm not exactly sure where to test this.
