### PR TITLE
Support automap option on repositories

### DIFF
--- a/lib/datamappify/config.rb
+++ b/lib/datamappify/config.rb
@@ -1,11 +1,11 @@
 module Datamappify
-  Config = Struct.new(:default_provider)
+  Config = Struct.new(:default_provider, :automap)
 
   # A Struct containing default configuration values
   #
   # @return [Config]
   def self.defaults
-    @defaults ||= Config.new
+    @defaults ||= Config.new(nil, true)
   end
 
   # @yield

--- a/lib/datamappify/data/mapper.rb
+++ b/lib/datamappify/data/mapper.rb
@@ -27,7 +27,7 @@ module Datamappify
         @custom_mapping         = {}
         @custom_attribute_names = []
         @references             = {}
-        @automap                = true
+        @automap                = Datamappify.defaults.automap
 
         @default_provider_name  = Datamappify.defaults.default_provider
       end

--- a/lib/datamappify/repository/mapping_dsl.rb
+++ b/lib/datamappify/repository/mapping_dsl.rb
@@ -3,6 +3,16 @@ module Datamappify
     module MappingDSL
       include LazyChecking
 
+      # @param automap [Boolean]
+      #   tells the repository whether or not to automatically
+      #   map all entity attributes to the underlying data
+      #   source
+      #
+      # @return [void]
+      def automap(automap)
+        data_mapper.automap = automap
+      end
+
       # If the entity is lazy loaded then it assigns
       # the repository itself back to the entity
       #

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,14 +1,33 @@
 require 'spec_helper'
 
 describe Datamappify do
-  before do
-    Datamappify.config do |c|
-      c.default_provider = :ActiveRecord
-    end
+  context 'defaults' do
+    subject { Datamappify.defaults }
+
+    its(:default_provider) { should be_nil }
+    its(:automap)          { should == true }
   end
 
-  it "#default_provider" do
-    mapper = Datamappify::Data::Mapper.new
-    mapper.default_provider_name.should == :ActiveRecord
+  context 'when configured' do
+    before do
+      Datamappify.config do |c|
+        c.default_provider = :ActiveRecord
+        c.automap          = false
+      end
+    end
+
+    describe 'defaults' do
+      subject { Datamappify.defaults }
+
+      its(:default_provider) { should == :ActiveRecord }
+      its(:automap)          { should == false }
+    end
+
+    describe 'mapper' do
+      subject { Datamappify::Data::Mapper.new }
+
+      its(:default_provider_name) { should == :ActiveRecord }
+      its(:automap)               { should == false }
+    end
   end
 end

--- a/spec/repository/not_automapped_spec.rb
+++ b/spec/repository/not_automapped_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+shared_examples_for "not automapped" do |data_provider|
+  let!(:dumb_user_repository) { "Dumb::UserRepository#{data_provider}".constantize }
+  let(:new_user)              { Dumb::User.new(:first_name => 'Fred', :last_name => 'Wu', :health_care => 'DONTPERSISTME') }
+
+  context "#{data_provider}" do
+
+    describe "persistence" do
+      before do
+        dumb_user_repository.save!(new_user)
+      end
+
+      describe "persisted attributes" do
+        subject { dumb_user_repository.save!(new_user) }
+
+        its(:id)          { should_not be_nil }
+        its(:first_name)  { should == 'Fred' }
+        its(:last_name)   { should == 'Wu' }
+        its(:health_care) { should == 'DONTPERSISTME' }
+      end
+
+      describe "finding" do
+        let!(:another_user) { Dumb::User.new(:first_name => "Benny", :last_name => "Boy", :health_care => 'DONTPERSISTME') }
+
+        let!(:saved_user) { dumb_user_repository.save!(another_user) }
+
+        subject { dumb_user_repository.find(saved_user.id) }
+
+        its(:id)          { should_not be_nil }
+        its(:first_name)  { should == 'Benny' }
+        its(:last_name)   { should == 'Boy' }
+        its(:health_care) { should be_nil }
+      end
+
+    end
+  end
+end
+
+describe Datamappify::Repository do
+  DATA_PROVIDERS.each do |data_provider|
+    it_behaves_like "not automapped", data_provider
+  end
+end
+

--- a/spec/support/entities/dumb/user.rb
+++ b/spec/support/entities/dumb/user.rb
@@ -1,0 +1,9 @@
+module Dumb
+  class User
+    include Datamappify::Entity
+
+    attribute :first_name,     String
+    attribute :last_name,      String
+    attribute :health_care,    String
+  end
+end

--- a/spec/support/repositories/active_record/dumb/user_repository.rb
+++ b/spec/support/repositories/active_record/dumb/user_repository.rb
@@ -1,0 +1,13 @@
+module Dumb
+  class UserRepositoryActiveRecord
+    include Datamappify::Repository
+
+    for_entity User
+    default_provider :ActiveRecord
+
+    automap false
+
+    map_attribute :first_name,     :to => 'Dumb::User#first_name'
+    map_attribute :last_name,      :to => 'Dumb::User#surname'
+  end
+end

--- a/spec/support/repositories/sequel/dumb/user_repository.rb
+++ b/spec/support/repositories/sequel/dumb/user_repository.rb
@@ -1,0 +1,14 @@
+module Dumb
+  class UserRepositorySequel
+    include Datamappify::Repository
+
+    for_entity User
+    default_provider :Sequel
+
+    automap false
+
+    map_attribute :first_name,     :to => 'Dumb::User#first_name'
+    map_attribute :last_name,      :to => 'Dumb::User#surname'
+  end
+end
+

--- a/spec/support/tables/active_record.rb
+++ b/spec/support/tables/active_record.rb
@@ -23,6 +23,12 @@ ActiveRecord::Migration.suppress_messages do
       t.timestamps
     end
 
+    create_table :dumb_users do |t|
+      t.string :first_name, :null => false
+      t.string :surname
+      t.timestamps
+    end
+
     create_table :comments do |t|
       t.string :content
       t.references :user

--- a/spec/support/tables/sequel.rb
+++ b/spec/support/tables/sequel.rb
@@ -23,6 +23,12 @@ DB.create_table :users do
   DateTime :updated_at
 end
 
+DB.create_table :dumb_users do
+  primary_key :id
+  String :first_name, :null => false
+  String :surname
+end
+
 DB.create_table :comments do
   primary_key :id
   String :content


### PR DESCRIPTION
Setting automap to false on a repo will prevent the repo
from attempting to map all entity attributes to the underlying
datasource.

See issue #17
