### PR TITLE
Ensure PersistentStates::Object tracks changes.

### DIFF
--- a/lib/datamappify/repository/unit_of_work/persistent_states/object.rb
+++ b/lib/datamappify/repository/unit_of_work/persistent_states/object.rb
@@ -76,8 +76,7 @@ module Datamappify
             end
           end
 
-          # Constructs an attribute setter, the setter itself does NOT need
-          # to set the value as the value is never going to be used.
+          # Constructs an attribute setter
           #
           # The setter sets the `attr_will_change!` flag when necessary.
           #
@@ -87,6 +86,7 @@ module Datamappify
           def construct_setter(name)
             define_singleton_method "#{name}=" do |value|
               send(:attribute_will_change!, name) unless send(name) == value
+              set_value(name, value)
             end
           end
 

--- a/spec/repository/dirty_tracking_spec.rb
+++ b/spec/repository/dirty_tracking_spec.rb
@@ -4,90 +4,86 @@ shared_examples_for "dirty tracking" do |data_provider|
   include_context "user repository", data_provider
 
   context "#{data_provider}" do
-    describe "entity attribute (simple)" do
+    describe 'entity attributes' do
       after do
         user_repository.save(existing_user)
-        user_repository.states.find(existing_user).first_name_changed?.should == false
+        user_repository.states.find(existing_user).changed?.should == false
+        user_repository.states.find(existing_user).changes.should be_empty
       end
 
       it "clean slate" do
         user_repository.states.find(existing_user).first_name_changed?.should == false
       end
 
-      it "changed" do
-        existing_user.first_name = 'ChangedName'
-        user_repository.states.find(existing_user).first_name_changed?.should == true
-        user_repository.states.find(existing_user).last_name_changed?.should == false
+      describe "change by assignment" do
+        it "changed" do
+          existing_user.first_name = 'ChangedName'
+          state = user_repository.states.find(existing_user)
+
+          state.first_name_changed?.should == true
+          state.last_name_changed?.should == false
+          state.changes.should == { 'first_name' => %w{Fred ChangedName} }
+        end
+
+        it "unchanged" do
+          first_name = existing_user.first_name
+          existing_user.first_name = 'ChangedName'
+          existing_user.first_name = first_name
+          state = user_repository.states.find(existing_user)
+
+          state.first_name_changed?.should == false
+          state.last_name_changed?.should == false
+          state.changes.should be_empty
+        end
       end
 
-      it "not changed" do
-        first_name = existing_user.first_name
-        existing_user.first_name = 'ChangedName'
-        existing_user.first_name = first_name
-        user_repository.states.find(existing_user).first_name_changed?.should == false
-        user_repository.states.find(existing_user).last_name_changed?.should == false
-      end
-    end
+      describe "change by mutation" do
 
-    describe "entity attribute (complex)" do
-      after do
-        user_repository.save(existing_user)
-        user_repository.states.find(existing_user).first_name_changed?.should == false
-      end
+        it "changed" do
+          existing_user.first_name << 'APPEND'
+          state = user_repository.states.find(existing_user)
 
-      it "changed" do
-        existing_user.first_name << 'super'
-        user_repository.states.find(existing_user).first_name_changed?.should == true
-        user_repository.states.find(existing_user).last_name_changed?.should == false
-      end
+          state.first_name_changed?.should == true
+          state.last_name_changed?.should == false
+          state.changes.should == { 'first_name' => %w{Fred FredAPPEND} }
+        end
 
-      it "not changed" do
-        first_name = existing_user.first_name.dup
-        existing_user.first_name << 'super'
-        existing_user.first_name = first_name
-        user_repository.states.find(existing_user).first_name_changed?.should == false
-        user_repository.states.find(existing_user).last_name_changed?.should == false
-      end
-    end
+        it "unchanged" do
+          first_name = existing_user.first_name.dup
+          existing_user.first_name << 'APPEND'
+          existing_user.first_name = first_name
+          state = user_repository.states.find(existing_user)
 
-    describe "entity" do
-      after do
-        user_repository.save(existing_user)
-        user_repository.states.find(existing_user).changed?.should == false
-      end
-
-      it "clean slate" do
-        user_repository.states.find(existing_user).changed?.should == false
-      end
-
-      it "changed" do
-        existing_user.first_name = 'ChangedName'
-        user_repository.states.find(existing_user).changed?.should == true
-      end
-
-      it "not changed" do
-        first_name = existing_user.first_name
-        existing_user.first_name = 'ChangedName'
-        existing_user.first_name = first_name
-        user_repository.states.find(existing_user).changed?.should == false
+          state.first_name_changed?.should == false
+          state.last_name_changed?.should == false
+          state.changes.should be_empty
+        end
       end
     end
 
     describe "manually mark as dirty" do
       it "marks an entity as dirty" do
         user_repository.states.mark_as_dirty(existing_user)
-        user_repository.states.find(existing_user).changed?.should == true
-        user_repository.states.find(existing_user).first_name_changed?.should == true
-        user_repository.states.find(existing_user).last_name_changed?.should == true
-        user_repository.states.find(existing_user).age_changed?.should == true
+        state = user_repository.states.find(existing_user)
+
+        state.changed?.should == true
+        state.first_name_changed?.should == true
+        state.last_name_changed?.should == true
+        state.age_changed?.should == true
+        state.changes.keys.should include('first_name')
+        state.changes.keys.should include('last_name')
+        state.changes.keys.should include('age')
       end
 
       it "marks entity attributes as dirty" do
         user_repository.states.mark_as_dirty(existing_user, :first_name, :age)
-        user_repository.states.find(existing_user).changed?.should == true
-        user_repository.states.find(existing_user).first_name_changed?.should == true
-        user_repository.states.find(existing_user).last_name_changed?.should == false
-        user_repository.states.find(existing_user).age_changed?.should == true
+        state = user_repository.states.find(existing_user)
+
+        state.changed?.should == true
+        state.first_name_changed?.should == true
+        state.last_name_changed?.should == false
+        state.age_changed?.should == true
+        state.changes.keys.should =~ %w{first_name age}
       end
     end
 
@@ -96,11 +92,13 @@ shared_examples_for "dirty tracking" do |data_provider|
 
       it "clean slate" do
         user_repository.states.find(user).first_name_changed?.should == false
+        user_repository.states.find(user).changes.should be_empty
       end
 
       it "changed" do
         user.first_name = 'Nexus'
         user_repository.states.find(user).first_name_changed?.should == true
+        user_repository.states.find(user).changes.should == { 'first_name' => %w{Fred Nexus} }
       end
     end
   end


### PR DESCRIPTION
Make the generated setter method actually set the changed value.
Ensure the changes output lists the changed attribute, with both
before and after values. e.g.

``` ruby
state.changes #=> { 'attribute_name' => ['old_value', 'new_value'] ... }
```
