### PR TITLE
Ensure that namespaced Entities get a correctly generated table.

### DIFF
--- a/lib/datamappify/data/mapper/attribute.rb
+++ b/lib/datamappify/data/mapper/attribute.rb
@@ -73,7 +73,7 @@ module Datamappify
         #
         # @return [Symbol]
         def source_table
-          @source_table ||= source_class_name.pluralize.underscore.to_sym
+          @source_table ||= ::Datamappify::Data::Provider.scoped_tableize(source_class_name).to_sym
         end
 
         # @return [Boolean]
@@ -83,7 +83,7 @@ module Datamappify
 
         # @return [String]
         def primary_provider_name
-          @primary_provider_name ||= primary_source_class.parent.to_s.demodulize
+          @primary_provider_name ||= primary_source_class.provider_name
         end
 
         # Foreign key of the primary record, useful for joins

--- a/lib/datamappify/data/provider.rb
+++ b/lib/datamappify/data/provider.rb
@@ -7,6 +7,17 @@ module Datamappify
 
       autoload :ActiveRecord
       autoload :Sequel
+
+      # Like the ActiveSupport.tableize inflector, but correctly
+      # converts class namespaces to valid table names.
+      #
+      # AS.tableize      'Foo::Fighter' => "foo/fighters"
+      # scoped_tableize  'Foo::Fighter' => "foo_fighters"
+      #
+      # @return [String]
+      def self.scoped_tableize(class_name)
+        class_name.gsub('::', '_').tableize
+      end
     end
   end
 end

--- a/lib/datamappify/data/provider/active_record.rb
+++ b/lib/datamappify/data/provider/active_record.rb
@@ -14,7 +14,7 @@ module Datamappify
             class_eval <<-CODE, __FILE__, __LINE__ + 1
               module Datamappify::Data::Record::ActiveRecord
                 class #{source_class_name} < ::ActiveRecord::Base
-                  self.table_name = '#{source_class_name.pluralize.gsub('::', '_').underscore}'
+                  self.table_name = '#{scoped_tableize(source_class_name)}'
                 end
               end
             CODE
@@ -38,6 +38,11 @@ module Datamappify
                          :class_name  => :"#{attribute.source_class.name}",
                          :foreign_key => :#{attribute.options[:via]}
             CODE
+          end
+
+          # @return [String]
+          def provider_name
+            'ActiveRecord'
           end
         end
       end

--- a/lib/datamappify/data/provider/common_provider.rb
+++ b/lib/datamappify/data/provider/common_provider.rb
@@ -39,7 +39,7 @@ module Datamappify
             record_class = source_class_name.safe_constantize
 
             # check for existing record class
-            if record_class && !entity_class?(source_class_name)
+            record_class = if record_class && !entity_class?(source_class_name)
               record_class
 
             # check for existing record class in the Datamappify::Data::Record::Provider namespace
@@ -50,9 +50,35 @@ module Datamappify
             else
               build_record_class(source_class_name)
             end
+
+            annotate_provider_name(record_class)
+            record_class
+          end
+
+          # A provider must provide it's name. e.g. ActiveRecord or Sequel
+          #
+          # @return [String]
+          def provider_name
+            raise NotImplementedError
           end
 
           private
+
+          # Ensure the record class knows the name of the provider that owns it.
+          #
+          # @param class_instance [Class]
+          def annotate_provider_name(record_class)
+            record_class.instance_eval <<-CODE, __FILE__, __LINE__ + 1
+              def provider_name
+                '#{provider_name}'
+              end
+            CODE
+          end
+
+          # @return [String]
+          def scoped_tableize(class_name)
+            ::Datamappify::Data::Provider.scoped_tableize(class_name)
+          end
 
           # @return [Boolean]
           def entity_class?(source_class_name)

--- a/lib/datamappify/data/provider/sequel.rb
+++ b/lib/datamappify/data/provider/sequel.rb
@@ -13,7 +13,7 @@ module Datamappify
           def build_record_class(source_class_name)
             class_eval <<-CODE, __FILE__, __LINE__ + 1
               module Datamappify::Data::Record::Sequel
-                class #{source_class_name} < ::Sequel::Model(:#{source_class_name.pluralize.gsub('::', '_').underscore})
+                class #{source_class_name} < ::Sequel::Model(:#{scoped_tableize(source_class_name)})
                   raise_on_save_failure = true
                   unrestrict_primary_key
                 end
@@ -43,6 +43,10 @@ module Datamappify
                           :class => :"#{attribute.source_class.name}",
                           :key   => :#{attribute.options[:via]}
             CODE
+          end
+
+          def provider_name
+            'Sequel'
           end
         end
       end

--- a/spec/support/tables/active_record.rb
+++ b/spec/support/tables/active_record.rb
@@ -112,5 +112,9 @@ ActiveRecord::Migration.suppress_messages do
       t.references :computer
       t.timestamps
     end
+
+    create_table :fridge_freezers do |t|
+      t.text :door
+    end
   end
 end

--- a/spec/support/tables/sequel.rb
+++ b/spec/support/tables/sequel.rb
@@ -138,3 +138,7 @@ DB.create_table :computer_component_softwares do |t|
   DateTime :created_at
   DateTime :updated_at
 end
+
+DB.create_table :fridge_freezers do |t|
+  String :door
+end

--- a/spec/unit/data/mapper/attribute_spec.rb
+++ b/spec/unit/data/mapper/attribute_spec.rb
@@ -8,14 +8,14 @@ describe Datamappify::Data::Mapper::Attribute do
       let(:record_class) { data_provider_class.find_or_build_record_class('Fridge::Freezer') }
 
       subject { described_class.new(:door,
-                                    to: 'Fridge::Freezer#door',
+                                    to: 'Fridge::Freezer#door_handle',
                                     provider: data_provider,
                                     primary_source_class: record_class ) }
 
       its(:provider_name)         { should == data_provider }
       its(:key)                   { should == :door }
       its(:name)                  { should == 'door' }
-      its(:source_attribute_name) { should == 'door' }
+      its(:source_attribute_name) { should == 'door_handle' }
       its(:source_class_name)     { should == 'Fridge::Freezer' }
       its(:source_table)          { should == :fridge_freezers }
     end

--- a/spec/unit/data/mapper/attribute_spec.rb
+++ b/spec/unit/data/mapper/attribute_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe Datamappify::Data::Mapper::Attribute do
+  DATA_PROVIDERS.each do |data_provider|
+    describe data_provider do
+      let(:data_provider_class) { "Datamappify::Data::Provider::#{data_provider}".constantize }
+
+      let(:record_class) { data_provider_class.find_or_build_record_class('Fridge::Freezer') }
+
+      subject { described_class.new(:door,
+                                    to: 'Fridge::Freezer#door',
+                                    provider: data_provider,
+                                    primary_source_class: record_class ) }
+
+      its(:provider_name)         { should == data_provider }
+      its(:key)                   { should == :door }
+      its(:name)                  { should == 'door' }
+      its(:source_attribute_name) { should == 'door' }
+      its(:source_class_name)     { should == 'Fridge::Freezer' }
+      its(:source_table)          { should == :fridge_freezers }
+    end
+  end
+end


### PR DESCRIPTION
This ensures that when using a namespaced Entity class, the table names are created using underscores instead of the default activesupport inflector behaviour, (slashes).
